### PR TITLE
Clean Makefiles up and remove need for esptool-ck (binary esptool)

### DIFF
--- a/embedded8266/Makefile
+++ b/embedded8266/Makefile
@@ -18,8 +18,8 @@ OPTS += -DICACHE_FLASH
 .PHONY : all clean cleanall netburn burnweb burn
 uniq = $(if $1,$(firstword $1) $(call uniq,$(filter-out $(firstword $1),$1)))
 
-FW_FILE_1 = 0x00000.bin
-FW_FILE_2 = 0x40000.bin
+FW_FILE1 = image.elf-0x00000.bin
+FW_FILE2 = image.elf-0x40000.bin
 TARGET = image.elf
 
 SRCS = \
@@ -44,7 +44,6 @@ INCL = $(SDK)/include myclib include .
 
 GCC_FOLDER = $(ESP_ROOT)/xtensa-lx106-elf
 ESPTOOL_PY = $(ESP_ROOT)/esptool/esptool.py
-FW_TOOL    = $(ESP_ROOT)/../esptool-ck/esptool
 SDK        = $(ESP_ROOT)/sdk
 
 XTLIB        = $(SDK)/lib
@@ -64,26 +63,21 @@ LINKFLAGS = $(LDFLAGS_CORE) -B$(XTLIB)
 
 ##########################################################################RULES
 
-all : $(FW_FILE_1) $(FW_FILE_2)
+all : $(FW_FILE1) $(FW_FILE2)
 
-$(FW_FILE_1): $(TARGET)
+$(FW_FILE1) $(FW_FILE2) : $(TARGET)
 	@echo "FW $@"
-	$(FW_TOOL) -eo $(TARGET) -bo $@ -bs .text -bs .data -bs .rodata -bc -ec
-
-$(FW_FILE_2): $(TARGET)
-	@echo "FW $@"
-	$(FW_TOOL) -eo $(TARGET) -es .irom0.text $@ -ec
+	PATH=$(FOLDERPREFIX):$$PATH;$(ESPTOOL_PY) elf2image $(TARGET)
 
 $(TARGET) : $(SRCS)
 	$(CC) $(CFLAGS) $^   $(LINKFLAGS) -o $@
-#	$(LD) $^ $(LDFLAGS) -o $@
 
 ifeq ($(CHIP), 8285)
 burn : $(FW_FILE_1) $(FW_FILE_2)
 	($(ESPTOOL_PY) --port $(PORT) write_flash -fs 8m -fm dout 0x00000 0x00000.bin 0x40000 0x40000.bin)||(true)
 else ifeq ($(CHIP), 8266)
 burn : $(FW_FILE_1) $(FW_FILE_2)
-	($(ESPTOOL_PY) --port $(PORT) write_flash 0x00000 0x00000.bin 0x40000 0x40000.bin)||(true)
+	($(ESPTOOL_PY) --port $(PORT) write_flash 0x00000 $(FW_FILE1) 0x40000 $(FW_FILE2))||(true)
 else
 	$(error Error: Unknown chip '$(CHIP)')
 endif
@@ -95,8 +89,8 @@ endif
 burnweb : web/page.mpfs
 	($(ESPTOOL_PY) --port $(PORT) write_flash 0x10000 web/page.mpfs)||(true)
 
-netburn : image.elf $(FW_FILE_1) $(FW_FILE_2)
-	web/execute_reflash $(IP) 0x00000.bin 0x40000.bin
+netburn : $(FW_FILE1) $(FW_FILE2) web/execute_reflash
+	web/execute_reflash $(IP) $(FW_FILE1) $(FW_FILE2)
 
 clean :
 	$(RM) $(patsubst %.c,%.o,$(SRCS)) $(TARGET)

--- a/embedded8266/Makefile
+++ b/embedded8266/Makefile
@@ -1,10 +1,29 @@
-FW_FILE_1:=0x00000.bin
-FW_FILE_2:=0x40000.bin
-TARGET_OUT:=image.elf
-all : $(TARGET_OUT) $(FW_FILE_1) $(FW_FILE_2)
+###############################################################################
+# USER OPTIONS
+###############################################################################
 
+CHIP  ?= 8266
+IP    ?= 192.168.4.1
+PORT  ?= /dev/ttyUSB0
+#PORT ?= /dev/ttyACM0
 
-SRCS:=driver/uart.c \
+ESP_ROOT ?= $(HOME)/esp8266/esp-open-sdk
+GCC_VERS ?= 4.8.5
+
+OPTS += -DICACHE_FLASH
+#OPTS += -DFREQ=12500
+
+###########################################################################VARS
+
+.PHONY : all clean cleanall netburn burnweb burn
+uniq = $(if $1,$(firstword $1) $(call uniq,$(filter-out $(firstword $1),$1)))
+
+FW_FILE_1 = 0x00000.bin
+FW_FILE_2 = 0x40000.bin
+TARGET = image.elf
+
+SRCS = \
+	driver/uart.c \
 	common/mystuff.c \
 	common/flash_rewriter.c \
 	common/http.c \
@@ -20,88 +39,67 @@ SRCS:=driver/uart.c \
 	user/user_main.c  \
 	common/commonservices.c
 
-GCC_FOLDER:=~/esp8266/esp-open-sdk/xtensa-lx106-elf
-ESPTOOL_PY:=~/esp8266/esptool/esptool.py
-FW_TOOL:=~/esp8266/other/esptool/esptool
-SDK:=/home/cnlohr/esp8266/esp_iot_sdk_v1.5.1
-PORT:=/dev/ttyUSB0
-#PORT:=/dev/ttyACM0
+LIBS = main lwip ssl upgrade net80211 wpa net80211 phy lwip pp crypto
+INCL = $(SDK)/include myclib include .
 
-XTLIB:=$(SDK)/lib
-XTGCCLIB:=$(GCC_FOLDER)/lib/gcc/xtensa-lx106-elf/4.8.2/libgcc.a
-FOLDERPREFIX:=$(GCC_FOLDER)/bin
-PREFIX:=$(FOLDERPREFIX)/xtensa-lx106-elf-
-CC:=$(PREFIX)gcc
+GCC_FOLDER = $(ESP_ROOT)/xtensa-lx106-elf
+ESPTOOL_PY = $(ESP_ROOT)/esptool/esptool.py
+FW_TOOL    = $(ESP_ROOT)/../esptool-ck/esptool
+SDK        = $(ESP_ROOT)/sdk
 
-CFLAGS:=-mlongcalls -I$(SDK)/include -Imyclib -Iinclude -Iuser -Os -I$(SDK)/include/ -I../embeddedcommon -I. -Icommon -DICACHE_FLASH
+XTLIB        = $(SDK)/lib
+XTGCCLIB     = $(GCC_FOLDER)/lib/gcc/xtensa-lx106-elf/$(GCC_VERS)/libgcc.a
+PREFIX       = $(GCC_FOLDER)/bin/xtensa-lx106-elf-
+CC           = $(PREFIX)gcc
+LD           = $(PREFIX)ld
 
-#-DFREQ==12500 seems to work well.
+CFLAGS = -mlongcalls -Os $(addprefix -I,$(INCL) $(call uniq, $(patsubst %/,%,$(dir $(SRCS))))) $(OPTS)
 
-
-LDFLAGS_CORE:=\
-	-nostdlib \
-	-L$(XTLIB) \
-	-L$(XTGCCLIB) \
-	$(SDK)/lib/libmain.a \
-	$(SDK)/lib/liblwip.a \
-	$(SDK)/lib/libssl.a \
-	$(SDK)/lib/libupgrade.a \
-	$(SDK)/lib/libnet80211.a \
-	$(SDK)/lib/libwpa.a \
-	$(SDK)/lib/libnet80211.a \
-	$(SDK)/lib/libphy.a \
-	$(SDK)/lib/liblwip.a \
-	$(SDK)/lib/libpp.a \
-	$(SDK)/lib/libcrypto.a \
-	$(SDK)/lib/libmain.a \
-	$(XTGCCLIB) \
-	-T $(SDK)/ld/eagle.app.v6.ld \
-	-Wl,-Map,output.map \
-
+LDFLAGS_CORE = -nostdlib -L$(XTLIB) -L$(XTGCCLIB) \
+	$(addprefix $(SDK)/lib/lib,$(addsuffix .a,$(LIBS))) \
+	$(XTGCCLIB) -T $(SDK)/ld/eagle.app.v6.ld -Wl,-Map,output.map
 #	-flto -Wl,--relax -Wl,--gc-sections
 
+LINKFLAGS = $(LDFLAGS_CORE) -B$(XTLIB)
 
-LINKFLAGS:= \
-	$(LDFLAGS_CORE) \
-	-B$(XTLIB)
+##########################################################################RULES
 
-#image.elf : $(OBJS)
-#	$(PREFIX)ld $^ $(LDFLAGS) -o $@
+all : $(FW_FILE_1) $(FW_FILE_2)
 
-$(TARGET_OUT) : $(SRCS)
-	$(PREFIX)gcc $(CFLAGS) $^   $(LINKFLAGS) -o $@
-
-
-
-$(FW_FILE_1): $(TARGET_OUT)
+$(FW_FILE_1): $(TARGET)
 	@echo "FW $@"
-	$(FW_TOOL) -eo $(TARGET_OUT) -bo $@ -bs .text -bs .data -bs .rodata -bc -ec
+	$(FW_TOOL) -eo $(TARGET) -bo $@ -bs .text -bs .data -bs .rodata -bc -ec
 
-$(FW_FILE_2): $(TARGET_OUT)
+$(FW_FILE_2): $(TARGET)
 	@echo "FW $@"
-	$(FW_TOOL) -eo $(TARGET_OUT) -es .irom0.text $@ -ec
+	$(FW_TOOL) -eo $(TARGET) -es .irom0.text $@ -ec
 
+$(TARGET) : $(SRCS)
+	$(CC) $(CFLAGS) $^   $(LINKFLAGS) -o $@
+#	$(LD) $^ $(LDFLAGS) -o $@
+
+ifeq ($(CHIP), 8285)
 burn : $(FW_FILE_1) $(FW_FILE_2)
-	#($(ESPTOOL_PY) --port $(PORT) write_flash 0x00000 0x00000.bin 0x40000 0x40000.bin)||(true) #for '8266
-	($(ESPTOOL_PY) --port $(PORT) write_flash -fs 8m -fm dout 0x00000 0x00000.bin 0x40000 0x40000.bin)||(true) #for '8285
-
-
+	($(ESPTOOL_PY) --port $(PORT) write_flash -fs 8m -fm dout 0x00000 0x00000.bin 0x40000 0x40000.bin)||(true)
+else ifeq ($(CHIP), 8266)
+burn : $(FW_FILE_1) $(FW_FILE_2)
+	($(ESPTOOL_PY) --port $(PORT) write_flash 0x00000 0x00000.bin 0x40000 0x40000.bin)||(true)
+else
+	$(error Error: Unknown chip '$(CHIP)')
+endif
 
 #If you have space, MFS should live at 0x100000, if you don't it can also live at
-#0x10000.  But, then it is limited to 180kB.  You might need to do this if you have a 512kB 
+#0x10000.  But, then it is limited to 180kB.  You might need to do this if you have a 512kB
 #ESP variant.
 
 burnweb : web/page.mpfs
 	($(ESPTOOL_PY) --port $(PORT) write_flash 0x10000 web/page.mpfs)||(true)
 
-
-
-IP?=192.168.4.1
-
 netburn : image.elf $(FW_FILE_1) $(FW_FILE_2)
 	web/execute_reflash $(IP) 0x00000.bin 0x40000.bin
 
 clean :
-	rm -rf user/*.o driver/*.o $(TARGET_OUT) $(FW_FILE_1) $(FW_FILE_2)
+	$(RM) $(patsubst %.c,%.o,$(SRCS)) $(TARGET)
 
-
+purge : clean
+	$(RM) $(FW_FILE_1) $(FW_FILE_2)

--- a/embedded8266/web/Makefile
+++ b/embedded8266/web/Makefile
@@ -1,23 +1,27 @@
-all : execute_reflash page.mpfs push 
+IP ?= 192.168.4.1
 
-IP?=192.168.4.1
+.PHONY : all clean push
+
+CFLAGS = -std=gnu99 -Wall -Wextra -O2 -march=native
+
+all : execute_reflash page.mpfs push
 
 mfsmaker : mfsmaker.c
-	gcc -o $@ $^
+	$(CC) $(CFLAGS) -o $@ $^
 
 page.mpfs : mfsmaker page
 #	cat to_compress/*.js | gzip -9 > page/compressed.js.gz
 	./mfsmaker page page.mpfs
 
 pushtodev : pushtodev.c
-	gcc -o $@ $^
+	$(CC) $(CFLAGS) -o $@ $^
 
 execute_reflash : execute_reflash.c md5.c
-	gcc -o $@ $^
+	$(CC) $(CFLAGS) -o $@ $^
 
 push : pushtodev page.mpfs
 	./pushtodev $(IP) 65536 page.mpfs
 #	./pushtodev $(IP) 1048576 page.mpfs
 
 clean :
-	rm -rf mfsmaker page.mpfs pushtodev execute_reflash
+	$(RM) mfsmaker page.mpfs pushtodev execute_reflash

--- a/embedded8266/web/pushtodev.c
+++ b/embedded8266/web/pushtodev.c
@@ -4,6 +4,7 @@
 
 #include <sys/socket.h>
 #include <netinet/in.h>
+#include <arpa/inet.h>
 #include <stdio.h>
 #include <sys/time.h>
 #include <sys/poll.h>


### PR DESCRIPTION
This is a streamlined version of the Makefile. 

 - Need for [esptool-ck](https://github.com/igrr/esptool-ck) removed
 - Easier to add library files, e.g. `libssl.a`
 - The location of the sdk  and other parameters (PORT, IP, CHIP, GCC_VERS, etc.) can now be specified with command line parameters, e.g. `make ESP_ROOT=/home/user/.local/espopensdk`. No need to edit the Makefile
 - Easier to add preprocessor options `OPTS+=-DMY_OPTION=1337`
 - Made some targets `.PHONY` so that they get run even if a recent file named after them exists (as in `touch clean`).
 - etc.

I tested some of it on Ubuntu 14.04.4 and 16.04.1. No problems were seen.

**Edit:**
I'm thinking of rewriting ./embedded8266/web/Makefile so that it can be included in the main Makefile and things like page.mpfs and execute_reflash are build automatically on demand from the main Makefile.