### PR TITLE
Utilize web/Makefile in the main Makefile (esp82XX)

### DIFF
--- a/embedded8266/Makefile
+++ b/embedded8266/Makefile
@@ -1,19 +1,4 @@
-###############################################################################
-# USER OPTIONS
-###############################################################################
-
-CHIP  ?= 8266
-IP    ?= 192.168.4.1
-PORT  ?= /dev/ttyUSB0
-#PORT ?= /dev/ttyACM0
-
-ESP_ROOT ?= $(HOME)/esp8266/esp-open-sdk
-GCC_VERS ?= 4.8.5
-
-OPTS += -DICACHE_FLASH
-#OPTS += -DFREQ=12500
-
-###########################################################################VARS
+include makeconf.inc   # Look here for user configuration
 
 .PHONY : all clean cleanall netburn burnweb burn
 uniq = $(if $1,$(firstword $1) $(call uniq,$(filter-out $(firstword $1),$1)))
@@ -42,16 +27,6 @@ SRCS = \
 LIBS = main lwip ssl upgrade net80211 wpa net80211 phy lwip pp crypto
 INCL = $(SDK)/include myclib include .
 
-GCC_FOLDER = $(ESP_ROOT)/xtensa-lx106-elf
-ESPTOOL_PY = $(ESP_ROOT)/esptool/esptool.py
-SDK        = $(ESP_ROOT)/sdk
-
-XTLIB        = $(SDK)/lib
-XTGCCLIB     = $(GCC_FOLDER)/lib/gcc/xtensa-lx106-elf/$(GCC_VERS)/libgcc.a
-PREFIX       = $(GCC_FOLDER)/bin/xtensa-lx106-elf-
-CC           = $(PREFIX)gcc
-LD           = $(PREFIX)ld
-
 CFLAGS = -mlongcalls -Os $(addprefix -I,$(INCL) $(call uniq, $(patsubst %/,%,$(dir $(SRCS))))) $(OPTS)
 
 LDFLAGS_CORE = -nostdlib -L$(XTLIB) -L$(XTGCCLIB) \
@@ -67,33 +42,36 @@ all : $(FW_FILE1) $(FW_FILE2)
 
 $(FW_FILE1) $(FW_FILE2) : $(TARGET)
 	@echo "FW $@"
-	PATH=$(FOLDERPREFIX):$$PATH;$(ESPTOOL_PY) elf2image $(TARGET)
+	export PATH="$(FOLDERPREFIX):$$PATH" $(ESPTOOL_PY) elf2image $(TARGET)
 
 $(TARGET) : $(SRCS)
 	$(CC) $(CFLAGS) $^   $(LINKFLAGS) -o $@
 
 ifeq ($(CHIP), 8285)
-burn : $(FW_FILE_1) $(FW_FILE_2)
+burn : $(FW_FILE1) $(FW_FILE2)
 	($(ESPTOOL_PY) --port $(PORT) write_flash -fs 8m -fm dout 0x00000 0x00000.bin 0x40000 0x40000.bin)||(true)
 else ifeq ($(CHIP), 8266)
-burn : $(FW_FILE_1) $(FW_FILE_2)
+burn : $(FW_FILE1) $(FW_FILE2)
 	($(ESPTOOL_PY) --port $(PORT) write_flash 0x00000 $(FW_FILE1) 0x40000 $(FW_FILE2))||(true)
 else
 	$(error Error: Unknown chip '$(CHIP)')
 endif
 
-#If you have space, MFS should live at 0x100000, if you don't it can also live at
-#0x10000.  But, then it is limited to 180kB.  You might need to do this if you have a 512kB
-#ESP variant.
-
-burnweb : web/page.mpfs
+burnweb :
+	@cd web && $(MAKE) $(MFLAGS) $(MAKEOVERRIDES) page.mpfs
 	($(ESPTOOL_PY) --port $(PORT) write_flash 0x10000 web/page.mpfs)||(true)
+#If you have space, MFS should live at 0x100000. It can also live at
+#0x10000. But, then it is limited to 180kB. You might need to do this if
+# you have a 512kB ESP variant.
 
-netburn : $(FW_FILE1) $(FW_FILE2) web/execute_reflash
+netburn : $(FW_FILE1) $(FW_FILE2)
+	@cd web && $(MAKE) $(MFLAGS) $(MAKEOVERRIDES) execute_reflash
 	web/execute_reflash $(IP) $(FW_FILE1) $(FW_FILE2)
 
 clean :
 	$(RM) $(patsubst %.c,%.o,$(SRCS)) $(TARGET)
 
 purge : clean
-	$(RM) $(FW_FILE_1) $(FW_FILE_2)
+	@cd web && $(MAKE) $(MFLAGS) $(MAKEOVERRIDES) clean
+	$(RM) $(FW_FILE1) $(FW_FILE2)
+

--- a/embedded8266/Makefile
+++ b/embedded8266/Makefile
@@ -42,7 +42,7 @@ all : $(FW_FILE1) $(FW_FILE2)
 
 $(FW_FILE1) $(FW_FILE2) : $(TARGET)
 	@echo "FW $@"
-	export PATH="$(FOLDERPREFIX):$$PATH" $(ESPTOOL_PY) elf2image $(TARGET)
+	export PATH="$(FOLDERPREFIX):$$PATH"; $(ESPTOOL_PY) elf2image $(TARGET)
 
 $(TARGET) : $(SRCS)
 	$(CC) $(CFLAGS) $^   $(LINKFLAGS) -o $@

--- a/embedded8266/README.md
+++ b/embedded8266/README.md
@@ -18,3 +18,9 @@ Unfortunately the I2S Out (WS2812 in) pin is the same as RX1 (pin 25), which mea
 
 The audio data is taken from TOUT, but must be kept between 0 and 1V.
 
+## Notes
+
+./makeconf.inc has a few variables that make uses for building and flashing the firmware. 
+Most notably the location of the toolchain for the esp8266/85 on your system.
+You should edit them according to your preferences or better add `export ESP_ROOT='/path/to/the/esp-open-sdk'` to your bashrc.
+

--- a/embedded8266/makeconf.inc
+++ b/embedded8266/makeconf.inc
@@ -1,0 +1,34 @@
+###############################################################################
+# USER OPTIONS
+###############################################################################
+
+CHIP  ?= 8266
+IP    ?= 192.168.4.1     # does not actually set the IP in firmware
+PORT  ?= /dev/ttyUSB0    # could also be /dev/ttyACM0
+PAGE_OFFSET ?= 65536     # 1048576
+
+SDK_DEFAULT  ?= $(HOME)/esp8266/esp-open-sdk
+ESP_GCC_VERS ?= 4.8.5
+
+OPTS += -DICACHE_FLASH
+#OPTS += -DFREQ=12500
+
+###########################################################################VARS
+
+GCC_FOLDER = $(ESP_ROOT)/xtensa-lx106-elf
+ESPTOOL_PY = $(ESP_ROOT)/esptool/esptool.py
+SDK        = $(ESP_ROOT)/sdk
+
+XTLIB        = $(SDK)/lib
+XTGCCLIB     = $(GCC_FOLDER)/lib/gcc/xtensa-lx106-elf/$(ESP_GCC_VERS)/libgcc.a
+FOLDERPREFIX = $(GCC_FOLDER)/bin
+PREFIX       = $(FOLDERPREFIX)/xtensa-lx106-elf-
+CC           = $(PREFIX)gcc
+LD           = $(PREFIX)ld
+AR           = $(PREFIX)ar
+
+ESP_ROOT := $(shell echo "$$ESP_ROOT")
+ifeq ($(strip $(ESP_ROOT)),)
+$(warning Warning: No shell variable 'ESP_ROOT', using '$(SDK_DEFAULT)')
+ESP_ROOT := $(SDK_DEFAULT)
+endif

--- a/embedded8266/web/Makefile
+++ b/embedded8266/web/Makefile
@@ -1,27 +1,23 @@
-IP ?= 192.168.4.1
+include ../makeconf.inc   # Look here for user configuration
 
 .PHONY : all clean push
+all : execute_reflash push
 
-CFLAGS = -std=gnu99 -Wall -Wextra -O2 -march=native
-
-all : execute_reflash page.mpfs push
+CC = gcc
 
 mfsmaker : mfsmaker.c
-	$(CC) $(CFLAGS) -o $@ $^
+pushtodev : pushtodev.c
+execute_reflash : execute_reflash.c md5.c
 
 page.mpfs : mfsmaker page
 #	cat to_compress/*.js | gzip -9 > page/compressed.js.gz
 	./mfsmaker page page.mpfs
 
-pushtodev : pushtodev.c
-	$(CC) $(CFLAGS) -o $@ $^
-
-execute_reflash : execute_reflash.c md5.c
-	$(CC) $(CFLAGS) -o $@ $^
+#mfsmaker pushtodev execute_reflash:
+#	$(CC) $(CFLAGS) -o $@ $^
 
 push : pushtodev page.mpfs
-	./pushtodev $(IP) 65536 page.mpfs
-#	./pushtodev $(IP) 1048576 page.mpfs
+	./pushtodev $(IP) $(PAGE_OFFSET) page.mpfs
 
 clean :
 	$(RM) mfsmaker page.mpfs pushtodev execute_reflash

--- a/embedded8266/web/execute_reflash.c
+++ b/embedded8266/web/execute_reflash.c
@@ -3,7 +3,9 @@
 
 #include <sys/socket.h>
 #include <netinet/in.h>
+#include <arpa/inet.h>
 #include <stdio.h>
+#include <unistd.h>
 #include <sys/time.h>
 #include <sys/poll.h>
 #include <sys/types.h>


### PR DESCRIPTION
 - Move user relevant make variables to `makeconf.inc`
 - Use `web/Makefile` for `burweb` and `netburn` targets in main Makefile (see [#12](https://github.com/cnlohr/colorchord/issues/12#issuecomment-237330199))
 - Reflect these changes in `README.md` 
 - Fix a few types from the previous merge
 - Fix missing includes in  in `execute_reflash.c`