### PR TITLE
Fixed a few things in Colorchord Embeddedlinux

### DIFF
--- a/embeddedlinux/Makefile
+++ b/embeddedlinux/Makefile
@@ -7,7 +7,7 @@ LDFLAGS:= -s -Wl,--relax -Wl,-Map=test.map  -Wl,--gc-sections -ffunction-section
 
 
 embeddedcc :  ../embeddedcommon/embeddednf.c ../embeddedcommon/DFT32.c embeddedcc.c  ../embeddedcommon/embeddedout.c
-	gcc -o $@ $^ $(CFLAGS) $(LDFLAGS) -m32
+	gcc -o $@ $^ $(CFLAGS) $(LDFLAGS)
 
 dummy_leds : dummy_leds.c 
 	gcc -o $@ $^ -lX11 -lpthread $(CFLAGS) $(LDFLAGS)

--- a/embeddedlinux/embeddedcc.c
+++ b/embeddedlinux/embeddedcc.c
@@ -11,6 +11,7 @@
 #include <string.h>
 #include <netinet/in.h>
 #include <stdio.h>
+#include <stdlib.h>   // Added by [olel] for atoi
 #include "embeddedout.h"
 
 struct sockaddr_in servaddr;
@@ -64,7 +65,7 @@ int main( int argc, char ** argv )
 
 	connect( sock, (struct sockaddr *)&servaddr, sizeof(servaddr) );
 
-	Init();
+	InitColorChord();  // Changed by [olel] cause this was changed in embeddednf
 
 	while( ( ci = getchar() ) != EOF )
 	{


### PR DESCRIPTION
Just added a header to use atoi and fixed rename of Init(); to InitColorChord();
I also remove -m32 to compile it on my 64bit computer