### PR TITLE
Add libudev-dev to dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Building with Linux
 -----------------
 Use `apt-get` to install the following packages for Debian/Ubuntu/Mint:
 ```
-apt-get install libpulse-dev libasound2-dev libx11-dev libxext-dev libxinerama-dev libusb-1.0-0-dev
+apt-get install libpulse-dev libasound2-dev libx11-dev libxext-dev libxinerama-dev libusb-1.0-0-dev libudev-dev
 ```
 
 To make colorchord, type:


### PR DESCRIPTION
Compilation might otherwise fail with
```
hidapi.c:2161:21: fatal error: libudev.h: No such file or directory
compilation terminated.
<builtin>: recipe for target 'hidapi.o' failed
make: *** [hidapi.o] Error 1
```