### PR TITLE
Bug fix broken code when APPROXNORM 1 and also bug fix for SORT_NOTES option.

### DIFF
--- a/embedded8266/ccconfig.h
+++ b/embedded8266/ccconfig.h
@@ -6,9 +6,9 @@
 #define HPABUFFSIZE 512
 
 #define CCEMBEDDED
-#define NUM_LIN_LEDS 541
+#define NUM_LIN_LEDS 16
 #define DFREQ 16000
-
+#define LUXETRON 0
 #define memcpy ets_memcpy
 #define memset ets_memset
 

--- a/embedded8266/user/ws2812_i2s.c
+++ b/embedded8266/user/ws2812_i2s.c
@@ -45,9 +45,8 @@ Extra copyright info:
 //Creates an I2S SR of 93,750 Hz, or 3 MHz Bitclock (.333us/sample)
 // 12000000L/(div*bestbck*2)
 //It is likely you could speed this up a little.
-#define LUXETRON
 
-#ifdef LUXETRON
+#if LUXETRON == 1
 #define INVERT
 #define WS_I2S_BCK 14
 #define WS_I2S_DIV 5

--- a/embeddedcommon/DFT32.c
+++ b/embeddedcommon/DFT32.c
@@ -192,6 +192,7 @@ void UpdateOutputBins32()
 		isps = isps<0? -isps : isps;
 		ispc = ispc<0? -ispc : ispc;
 		uint32_t rmux = isps>ispc? isps + (ispc>>1) : ispc + (isps>>1);
+		rmux = rmux>>16;
 #else
 		uint32_t rmux = ( (isps) * (isps)) + ((ispc) * (ispc));
 		rmux = SquareRootRounded( rmux );

--- a/embeddedcommon/embeddedout.c
+++ b/embeddedcommon/embeddedout.c
@@ -61,17 +61,17 @@ void UpdateLinearLEDs()
 		{
 			if( note_peak_freqs[ sorted_note_map[j] ] > nff )
 			{
-				break;
+				break; // so j is correct place to insert
 			}
 		}
-		for( k = sorted_map_count; k > j; k-- )
+		for( k = sorted_map_count; k > j; k-- ) // make room
 		{
 			sorted_note_map[k] = sorted_note_map[k-1];
 		}
-		sorted_note_map[j] = i;
+		sorted_note_map[j] = i; // insert in correct place
 #else
+		sorted_note_map[sorted_map_count] = i; // insert at end
 #endif
-		sorted_note_map[sorted_map_count] = i;
 		sorted_map_count++;
 	}
 


### PR DESCRIPTION
Hi Charles, 

22 May 2019:
      I've added a bit more to masterfix since submitting the pull request. 
IMPORTANT - my previous commit has a bug and breaks embedded CC. 
This is fixed now with the addition of one line in DFT32.c

Comments when submitted. 
      Sorting has a small bug.  The insertion of note index is being done at the correct place in the order, but also (again) at the end. This fixes it. 

On my fork, I have replaced the insertion sort by a bubble sort and set it up so sort on freq, amp1, or amp2. 

Also NERF_NOTE_PORP does not work correctly. 
Example: We have 9 notes with the following amp:
10000,20000,30000,40000,50000,40011,20022,30033,10011
NERF_NOTE_PORP of 32  = 12.5% = 32/256
The method now rejects all but these 50000,40011,40000
So displays them with 3 arcs in the proportions 38.5%, 30.8% and 30.7%

However showing these 5 notes
50000,40011,40000,30033,30000, have percentages 26.3, 21.0, 21.0 ,15.8, 15.7 all bigger than 12.5%

 