### PR TITLE
Fixed bug when APPROXNORM == 1 is used when CCEMBEDDED is not defined…

### DIFF
--- a/embeddedcommon/DFT32.c
+++ b/embeddedcommon/DFT32.c
@@ -168,33 +168,32 @@ void UpdateOutputBins32()
 	int32_t * ipt = &Sdatspace32BOut[0];
 	for( i = 0; i < FIXBINS; i++ )
 	{
-#if APPROXNORM == 1
-		int32_t isps = *(ipt++); //can keep 32 bits as no need to square
+		int32_t isps = *(ipt++); //keep 32 bits
 		int32_t ispc = *(ipt++);
-#else
-		int16_t isps = *(ipt++)>>16; //might loose some precision with this
-		int16_t ispc = *(ipt++)>>16;
-#endif
-
+		// take absolute values
+		isps = isps<0? -isps : isps;
+		ispc = ispc<0? -ispc : ispc;
 		int octave = i / FIXBPERO;
 
 		//If we are running DFT32 on regular ColorChord, then we will need to
 		//also update goutbins[]... But if we're on embedded systems, we only
 		//update embeddedbins32.
 #ifndef CCEMBEDDED
-		uint32_t mux = ( (isps) * (isps)) + ((ispc) * (ispc));
-		goutbins[i] = sqrtf( (float)mux );
+		// convert 32 bit precision isps and ispc to floating point
+		float mux = ( (float)isps * (float)isps) + ((float)ispc * (float)ispc);
+		goutbins[i] = sqrtf(mux)/65536.0; // scale by 2^16
 		//reasonable (but arbitrary attenuation)
 		goutbins[i] /= (78<<DFTIIR)*(1<<octave); 
 #endif
 
 #if APPROXNORM == 1
-		isps = isps<0? -isps : isps;
-		ispc = ispc<0? -ispc : ispc;
+		// using full 32 bit precision for isps and ispc
 		uint32_t rmux = isps>ispc? isps + (ispc>>1) : ispc + (isps>>1);
-		rmux = rmux>>16;
+		rmux = rmux>>16; // keep most significant 16 bits
 #else
-		uint32_t rmux = ( (isps) * (isps)) + ((ispc) * (ispc));
+		// use the most significant 16 bits of isps and ispc when squaring
+		// since isps and ispc are non-negative right bit shifing is well defined
+		uint32_t rmux = ( (isps>>16) * (isps>>16)) + ((ispc>16) * (ispc>>16));
 		rmux = SquareRootRounded( rmux );
 #endif
 

--- a/embeddedcommon/DFT32.h
+++ b/embeddedcommon/DFT32.h
@@ -24,9 +24,7 @@
 // Will used simple approximation of norm rather than
 //   sum squares and approx sqrt
 #ifndef APPROXNORM
-//XXX CNL: BBKiwi added this feature but it seems to break stuff.
-//For now, the correct behavior should be to default without approxnorm.
-//#define APPROXNORM 1
+#define APPROXNORM 1
 #endif
 
 #ifndef OCTAVES


### PR DESCRIPTION
Hi Charles, 

I'm able to run colorchord2 again (libudev.h somehow went missing, I had to apt-get  install libudev-dev). I tested both with colorchord2 default and embedded8266 version.  

I read up on right bit shifting a negative integer and apparently it is implementation dependent, so the code is now slightly rearranged so it shifts non-negative values. 

I  used grep to search all the code in colorchord2 and embeddedbins32 is never used. 
Could a return be added after
`goutbins[i] /= (78<<DFTIIR)*(1<<octave); `