### PR TITLE
Fix bug(?) if dft.c

### DIFF
--- a/colorchord2/dft.c
+++ b/colorchord2/dft.c
@@ -420,9 +420,12 @@ uint16_t Sdatspace[FIXBINS*4];  //(advances,places,isses,icses)
 static uint8_t Sdo_this_octave[BINCYCLE];
 static int16_t Saccum_octavebins[OCTAVES];
 static uint8_t Swhichoctaveplace;
-#ifndef INCLUDING_EMBEDDED
-uint16_t embeddedbins[FIXBINS]; //This is updated every time the DFT hits the octavecount, or 1/32 updates.
-#endif
+
+//multiple definition of `embeddedbins'; dft.o (symbol from plugin):(.text+0x0): first defined here
+//Had this issue when trying to build, commenting this lines out made the build successful
+//#ifndef INCLUDING_EMBEDDED
+//uint16_t embeddedbins[FIXBINS]; //This is updated every time the DFT hits the octavecount, or 1/32 updates.
+//#endif
 
 //From: http://stackoverflow.com/questions/1100090/looking-for-an-efficient-integer-square-root-algorithm-for-arm-thumb2
 /**


### PR DESCRIPTION
I am running Pop_os 20.10
After running the instructions on the page and cloning the repo, when I tried to make it I got the following error:

/usr/bin/ld: ../embeddedcommon/DFT32.o (symbol from plugin): in function `Sdatspace32B':
(.text+0x0): multiple definition of `embeddedbins'; dft.o (symbol from plugin):(.text+0x0): first defined here
collect2: error: ld returned 1 exit status
make: *** [Makefile:20: colorchord] Error 1

After messing around for a few minutes, I tried commenting out the lines of code from the file dft.c where embeddedbins was defined. And by doing that I was able to make the project and run it and it seems to be running fine.

Looked around and it seems like I am the only one with that error, but this was the only way I was able to get it to compile