### PR TITLE
docs: fix simple typo, thurroughly -> thoroughly

### DIFF
--- a/embedded8266/README.md
+++ b/embedded8266/README.md
@@ -18,7 +18,7 @@ Unfortunately the I2S Out (WS2812 in) pin is the same as RX1 (pin 25), which mea
 
 The audio data is taken from TOUT, but must be kept between 0 and 1V.
 
-An option that has been thurroughly tested is for use with the 2019 MAGFest Swadge.  https://github.com/cnlohr/swadge2019
+An option that has been thoroughly tested is for use with the 2019 MAGFest Swadge.  https://github.com/cnlohr/swadge2019
 
 Audio portion:
 ![Audio portion of schematic](https://raw.githubusercontent.com/cnlohr/swadge2019/master/hardware/swadge2019_schematic_audio.png)


### PR DESCRIPTION
There is a small typo in embedded8266/README.md.

Should read `thoroughly` rather than `thurroughly`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md