### PR TITLE
Fixing rare out-of-bounds crash

### DIFF
--- a/colorchord2/decompose.c
+++ b/colorchord2/decompose.c
@@ -24,7 +24,7 @@ int DecomposeHistogram( float * histogram, int bins, struct NoteDists * out_dist
 		float this = histogram[i];
 		float next = histogram[(i+1)%bins];
 
-		if( prev > this || next > this ) continue;
+		if( prev >= this || next > this ) continue;
 		if( prev == this && next == this ) continue;
 
 		//i is at a peak... 


### PR DESCRIPTION
In the event that adjacent DFT bins have perfectly equal values, the current peak detector will count each one of those bins as a peak. Due to the bins being floating-point numbers, any 2 bins being equal (and not 0) is probably very rare.

However, we observed a crash in ColorChord.NET where when the DFT bin values were extremely small (a few times the smallest `float32` increment), and enough adjacent bins had actually equal values, there can be more than 12 "peaks" detected. This causes an out-of-bounds access, which crashes CC.NET. Not sure what it would do to the C version, but it's probably not good.

![image](https://user-images.githubusercontent.com/6701127/103433597-3f122c80-4c37-11eb-9b2e-888bd117adbd.png)
This was the data we were debugging against, y-axis is multiples of the smallest possible `float32` value, 1.4012984643E-45.
In this, it should detect only a few peaks (and in any case, there mathematically should not be more than 12 peaks), however in this case it outputs 1, 2, 5, 6, 8, 9, 12, 13, 15, 17, 18, 21, 23.

I've only encountered this very rarely, and Nikky's report was the first time I was able to debug the crash. (I noticed my CC.NET running on my media center PC would crash occasionally, but never bothered to debug. After I made this cahnge it's never crashed since)

See the related discussion on the #colorchord channel in Discord for more details.