### PR TITLE
Fix color representation bugs

### DIFF
--- a/colorchord2/DisplayArray.c
+++ b/colorchord2/DisplayArray.c
@@ -54,7 +54,7 @@ static void DPOUpdate(void * id, struct NoteFinder*nf)
 		{
 			index = x+y*d->xn;
 		}
-		CNFGColor(  OutLEDs[index*3+0] | (OutLEDs[index*3+1] <<8)|(OutLEDs[index*3+2] <<16) );
+		CNFGColor(  (OutLEDs[index*3+0] <<24) | (OutLEDs[index*3+1] <<16) | (OutLEDs[index*3+2] <<8) | 0xff );
 		float dx = (x) * cw;
 		float dy = (y) * ch;
 
@@ -63,7 +63,7 @@ static void DPOUpdate(void * id, struct NoteFinder*nf)
 		else
 			CNFGTackRectangle( dx, dy, dx+cw+.5, dy+ch+.5 );
 	}
-	CNFGColor( 0xffffff );
+	CNFGColor( 0xffffffff );
 }
 
 static void DPOParams(void * id )

--- a/colorchord2/DisplayOUTDriver.c
+++ b/colorchord2/DisplayOUTDriver.c
@@ -130,9 +130,9 @@ static void DPOUpdate(void * id, struct NoteFinder*nf)
 		if( sat > 1 ) sat = 1;
 		uint32_t color = CCtoHEX( nf->note_positions[i] / nf->freqbins, 1.0, sat );
 
-		OutLEDs[led*3+0] = color & 0xff;
-		OutLEDs[led*3+1] = ( color >> 8 ) & 0xff;
-		OutLEDs[led*3+2] = ( color >> 16 ) & 0xff;
+		OutLEDs[led*3+0] = ( color >> 24 ) & 0xff;
+		OutLEDs[led*3+1] = ( color >> 16 ) & 0xff;
+		OutLEDs[led*3+2] = ( color >> 8 ) & 0xff;
 		led++;
 
 	}

--- a/colorchord2/DisplayPie.c
+++ b/colorchord2/DisplayPie.c
@@ -53,13 +53,13 @@ static void DPOUpdate(void * id, struct NoteFinder*nf)
 		pts[5].x = cw + cos(angB) * sizeA;
 		pts[5].y = ch + sin(angB) * sizeA;
 
-		CNFGColor(  OutLEDs[i*3+0] | (OutLEDs[i*3+1] <<8)|(OutLEDs[i*3+2] <<16) );
+		CNFGColor( ( OutLEDs[i*3+0] <<24) | (OutLEDs[i*3+1] <<16) | (OutLEDs[i*3+2] <<8) | 0xff );
 		CNFGTackPoly( pts, 3 );
 		CNFGTackPoly( pts+3, 3 );
 	}
 
 
-	CNFGColor( 0xffffff );
+	CNFGColor( 0xffffffff );
 }
 
 static void DPOParams(void * id )

--- a/colorchord2/DisplayRadialPoles.c
+++ b/colorchord2/DisplayRadialPoles.c
@@ -65,7 +65,7 @@ static void DPRUpdate(void * id, struct NoteFinder*nf)
 			CNFGTackPoly( pts+3, 3 );
 
 
-			CNFGColor( 0x00000000 );
+			CNFGColor( 0x000000ff );
 			CNFGTackSegment( p1x, p1y, p2x, p2y);
 			CNFGTackSegment( p2x, p2y, p4x, p4y);
 			CNFGTackSegment( p3x, p3y, p1x, p1y);
@@ -114,7 +114,7 @@ static void DPRUpdate(void * id, struct NoteFinder*nf)
 			CNFGTackPoly( pts, 3 );
 			CNFGTackPoly( pts+3, 3 );
 
-			CNFGColor( 0x00000000 );
+			CNFGColor( 0x000000ff );
 			CNFGTackSegment( p1x, p1y, p2x, p2y);
 			CNFGTackSegment( p2x, p2y, p4x, p4y);
 			CNFGTackSegment( p3x, p3y, p1x, p1y);
@@ -124,7 +124,7 @@ static void DPRUpdate(void * id, struct NoteFinder*nf)
 
 
 
-	CNFGColor( 0xffffff );
+	CNFGColor( 0xffffffff );
 }
 
 static void DPRParams(void * id )

--- a/colorchord2/OutputCells.c
+++ b/colorchord2/OutputCells.c
@@ -187,9 +187,9 @@ static void LEDUpdate(void * id, struct NoteFinder*nf)
 		if( sendsat > 1 ) sendsat = 1;
 		int r = CCtoHEX( binpos[ia], 1.0, pow( sendsat, led->outgamma ) );
 
-		OutLEDs[i*3+0] = r & 0xff;
-		OutLEDs[i*3+1] = (r>>8) & 0xff;
-		OutLEDs[i*3+2] = (r>>16) & 0xff;
+		OutLEDs[i*3+0] = (r>>24) & 0xff;
+		OutLEDs[i*3+1] = (r>>16) & 0xff;
+		OutLEDs[i*3+2] = (r>>8) & 0xff;
 	}
 
 }

--- a/colorchord2/OutputLinear.c
+++ b/colorchord2/OutputLinear.c
@@ -180,9 +180,9 @@ static void LEDUpdate(void * id, struct NoteFinder*nf)
 
 		int r = CCtoHEX( led->last_led_pos[i], 1.0, pow( sendsat, led->outgamma ) );
 
-		OutLEDs[i*3+0] = r & 0xff;
-		OutLEDs[i*3+1] = (r>>8) & 0xff;
-		OutLEDs[i*3+2] = (r>>16) & 0xff;
+		OutLEDs[i*3+0] = (r>>24) & 0xff;
+		OutLEDs[i*3+1] = (r>>16) & 0xff;
+		OutLEDs[i*3+2] = (r>>8) & 0xff;
 	}
 
 	if( led->is_loop )

--- a/colorchord2/OutputProminent.c
+++ b/colorchord2/OutputProminent.c
@@ -43,18 +43,16 @@ static void LEDUpdate(void * id, struct NoteFinder*nf)
 		}
 	}
 
-
+	float sendsat = selected_amp;
+	if( sendsat > 1 ) sendsat = 1;
+	int r = CCtoHEX( selected_note, 1.0, sendsat );
 
 	//Advance the LEDs to this position when outputting the values.
 	for( i = 0; i < led->total_leds; i++ )	
 	{
-		float sendsat = selected_amp;
-		if( sendsat > 1 ) sendsat = 1;
-		int r = CCtoHEX( selected_note, 1.0, sendsat );
-
-		OutLEDs[i*3+0] = r & 0xff;
-		OutLEDs[i*3+1] = (r>>8) & 0xff;
-		OutLEDs[i*3+2] = (r>>16) & 0xff;
+		OutLEDs[i*3+0] = (r>>24) & 0xff;
+		OutLEDs[i*3+1] = (r>>16) & 0xff;
+		OutLEDs[i*3+2] = (r>>8) & 0xff;
 	}
 
 }

--- a/colorchord2/OutputVoronoi.c
+++ b/colorchord2/OutputVoronoi.c
@@ -131,9 +131,9 @@ static void DPOUpdate(void * id, struct NoteFinder*nf)
 			color = CCtoHEX( note_color, 1.0, pow( sat, d->outgamma ) );
 		}
 
-		OutLEDs[led*3+0] = color & 0xff;
-		OutLEDs[led*3+1] = ( color >> 8 ) & 0xff;
-		OutLEDs[led*3+2] = ( color >> 16 ) & 0xff;
+		OutLEDs[led*3+0] = ( color >> 24 ) & 0xff;
+		OutLEDs[led*3+1] = ( color >> 16 ) & 0xff;
+		OutLEDs[led*3+2] = ( color >> 8 ) & 0xff;
 		led++;
 	}
 }


### PR DESCRIPTION
Changed 0x00BBGGRR (0BGR) to 0xRRGGBBAA (RGBA) in places.
The diagrams on screen didn't have any red colors. Red color component was missing.

Tested on 64 bit Windows 7 with Service Pack 1 with NVIDIA GeForce GTX 750 Ti and TCC 0.9.27 64 bit

There's some bug with outline color. Binary in repo produces white outlines (and broken red color component in diagrams), but when I compiled, they turned cyan.

Screenshots before and after
![Before (broken red)](https://user-images.githubusercontent.com/15855754/140577716-a7deb050-b853-4ce3-b1fa-347304bd26ce.png)
![After](https://user-images.githubusercontent.com/15855754/140577782-b5256615-0d77-4c65-9c56-4efc0068f373.png)

color shi(f)t